### PR TITLE
docs(tutorial): fix markdown formatting in Polkadot.js wallet guide

### DIFF
--- a/tutorials/wallet-with-polkadot-js-and-react-with-typescript/3-step3.mdx
+++ b/tutorials/wallet-with-polkadot-js-and-react-with-typescript/3-step3.mdx
@@ -56,7 +56,7 @@ For this step we will use the following 3 components in the polkadot libraries, 
 
 **Keyring:** This function generates the public and private key, it is found in the '@polkadot/api' library.
 
-**waitReady:**This function used to wait for WebAssembly (Wasm) cryptographic modules to be fully loaded and ready for use, it is found in the '@polkadot/wasm-crypto' library.
+**waitReady**: This function used to wait for WebAssembly (Wasm) cryptographic modules to be fully loaded and ready for use, it is found in the '@polkadot/wasm-crypto' library.
 
 To import these components in the library, we can use the following code:
  ```ts title=src/pages/newaccount/newaccounts.tsx

--- a/tutorials/wallet-with-polkadot-js-and-react-with-typescript/5-step5.mdx
+++ b/tutorials/wallet-with-polkadot-js-and-react-with-typescript/5-step5.mdx
@@ -25,7 +25,7 @@ Additionally, this component will need to use 3 components from the '@polkadot/e
 
 **web3Enable:** This function returns a promise that resolves to an enabled Polkadot.js provider object if the user grants the necessary permissions. 
 
-**web3FromSource:**This function is used to obtain a signed account object from a specific source, such as an account in the Polkadot.js browser extension. 
+**web3FromSource**: This function is used to obtain a signed account object from a specific source, such as an account in the Polkadot.js browser extension. 
 
 We will import the following:
 


### PR DESCRIPTION
## Affected tutorial  
`/tutorials/wallet-with-polkadot-js-and-react-with-typescript`

## Changes  
- Fixed broken delimiters  